### PR TITLE
Update bootstrap-table-filter-control.js

### DIFF
--- a/src/extensions/filter-control/bootstrap-table-filter-control.js
+++ b/src/extensions/filter-control/bootstrap-table-filter-control.js
@@ -93,7 +93,7 @@
 
     var getCursorPosition = function(el) {
         if ($.fn.bootstrapTable.utils.isIEBrowser()) {
-            if ($(el).is('input')) {
+            if ($(el).is('input[type="text"]')) {
                 var pos = 0;
                 if ('selectionStart' in el) {
                     pos = el.selectionStart;


### PR DESCRIPTION
filter was not working in IE browser if we have  
 data-checkbox="true" column in table.